### PR TITLE
Support long ids.

### DIFF
--- a/src/connector.js
+++ b/src/connector.js
@@ -8,6 +8,7 @@ const TableManager = require( './table-manager' )
 const dataTransform = require( './transform-data' )
 const pckg = require( '../package.json' )
 const PRIMARY_KEY = require( './primary-key')
+const crypto = require( 'crypto' )
 
 class Connector extends EventEmitter {
 
@@ -157,12 +158,15 @@ class Connector extends EventEmitter {
    */
   _getParams( key ) {
     const parts = key.split( this._splitChar )
+    const params = parts.length === 2
+      ? { table: parts[ 0 ], id: parts[ 1 ] }
+      : { table: this._defaultTable, id: key }
 
-    if( parts.length === 2 ) {
-      return { table: parts[ 0 ], id: parts[ 1 ] }
-    } else {
-      return { table: this._defaultTable, id: key }
+    if (params.id.length > 127) {
+      params.id = crypto.createHash('sha1').update(params.id).digest("hex")
     }
+
+    return params
   }
 
   /**


### PR DESCRIPTION
This is especially useful when using the `table/id?options` format where ids easily can exceed the 127 character limit.

I've encountered some really confusing bugs due to this limitation.