### PR TITLE
Don't throw an error if the RethinkDB port is a String

### DIFF
--- a/src/connector.js
+++ b/src/connector.js
@@ -197,7 +197,7 @@ class Connector extends EventEmitter {
     if( typeof options.host !== 'string' ) {
       throw new Error( 'Missing option host' )
     }
-    if( typeof options.port !== 'number' ) {
+    if( isNaN( options.port ) ) {
       throw new Error( 'Missing option port' )
     }
   }


### PR DESCRIPTION
Using `isNaN` to validate the port option instead of typeof.

```js
typeof '1234' === 'string'
typeof 1234 === 'number'
typeof 'foo' === 'string'
```

```js
isNaN('1234') === false
isNaN(1234) === false
isNaN('foo') === true
```